### PR TITLE
chore: Updated the default neard version to 1.40.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,11 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        node-version: ['14', '15', '16']
+        node-version: ['latest', 'lts/*']
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Run tests

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -11,8 +11,8 @@ pub mod sync;
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v1.39.2 released on May 22, 2024
-pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "1.39.2/a0f74bb99341a11d0978c3cf85ef428ee935fdbd";
+// Currently pointing to nearcore@v1.40.0 released on June 17, 2024
+pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "1.40.0/7dd0b5993577f592be15eb102e5a3da37be66271";
 
 const fn platform() -> Option<&'static str> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -11,8 +11,8 @@ pub mod sync;
 
 // The current version of the sandbox node we want to point to.
 // Should be updated to the latest release of nearcore.
-// Currently pointing to nearcore@v1.38.0 released on March 18, 2024
-pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "1.38.0/aac5e42fe8975e27faca53e31f53f9c67a5b4e35";
+// Currently pointing to nearcore@v1.39.2 released on May 22, 2024
+pub const DEFAULT_NEAR_SANDBOX_VERSION: &str = "1.39.2/a0f74bb99341a11d0978c3cf85ef428ee935fdbd";
 
 const fn platform() -> Option<&'static str> {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -17,7 +17,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.39.2/a0f74bb99341a11d0978c3cf85ef428ee935fdbd/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.40.0/7dd0b5993577f592be15eb102e5a3da37be66271/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {

--- a/npm/src/getBinary.ts
+++ b/npm/src/getBinary.ts
@@ -17,7 +17,7 @@ function getPlatform() {
 
 export function AWSUrl(): string {
   const [platform, arch] = getPlatform();
-  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.38.0/aac5e42fe8975e27faca53e31f53f9c67a5b4e35/near-sandbox.tar.gz`;
+  return `https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${platform}-${arch}/1.39.2/a0f74bb99341a11d0978c3cf85ef428ee935fdbd/near-sandbox.tar.gz`;
 }
 
 export function getBinary(name: string = "near-sandbox"): Promise<Binary> {


### PR DESCRIPTION
It is not a breaking change since no API changes could break the old contracts or RPC clients.