### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox-utils"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "binary-install",

--- a/crate/CHANGELOG.md
+++ b/crate/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/near/near-sandbox/compare/v0.8.0...v0.9.0) - 2024-07-05
+
+### Added
+- Avoid different versions of near-sandbox binaries collision ([#72](https://github.com/near/near-sandbox/pull/72))
+
+### Other
+- Updated the default neard version to 1.40.0 ([#85](https://github.com/near/near-sandbox/pull/85))
+
 ## [0.8.0](https://github.com/near/near-sandbox/compare/v0.7.0...v0.8.0) - 2024-06-11
 
 ### Added

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION
## 🤖 New release
* `near-sandbox-utils`: 0.8.0 -> 0.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/near/near-sandbox/compare/v0.8.0...v0.9.0) - 2024-07-05

### Added
- Avoid different versions of near-sandbox binaries collision ([#72](https://github.com/near/near-sandbox/pull/72))

### Other
- Updated the default neard version to 1.40.0 ([#85](https://github.com/near/near-sandbox/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).