### PR TITLE
chore: release v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox-utils"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "binary-install",

--- a/crate/CHANGELOG.md
+++ b/crate/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/near/near-sandbox/compare/v0.9.0...v0.10.0) - 2024-08-15
+
+### Other
+- [**breaking**] updated neard to 2.0.0 ([#88](https://github.com/near/near-sandbox/pull/88))
+
 ## [0.9.0](https://github.com/near/near-sandbox/compare/v0.8.0...v0.9.0) - 2024-07-05
 
 ### Added

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION
## 🤖 New release
* `near-sandbox-utils`: 0.9.0 -> 0.10.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/near/near-sandbox/compare/v0.9.0...v0.10.0) - 2024-08-15

### Other
- [**breaking**] updated neard to 2.0.0 ([#88](https://github.com/near/near-sandbox/pull/88))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).