### PR TITLE
chore: release v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox-utils"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "binary-install",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox-utils"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "binary-install",

--- a/crate/CHANGELOG.md
+++ b/crate/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/near/near-sandbox/compare/v0.11.0...v0.11.1) - 2024-11-15
+
+### Other
+
+- Updated near-sandbox version to 2.3.1 version ([#103](https://github.com/near/near-sandbox/pull/103))
+
 ## [0.11.0](https://github.com/near/near-sandbox/compare/v0.10.0...v0.11.0) - 2024-09-06
 
 ### Other

--- a/crate/CHANGELOG.md
+++ b/crate/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.1](https://github.com/near/near-sandbox/compare/v0.11.0...v0.11.1) - 2024-11-15
+## [0.12.0](https://github.com/near/near-sandbox/compare/v0.11.0...v0.12.0) - 2024-11-15
 
 ### Other
 

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION
## 🤖 New release
* `near-sandbox-utils`: 0.11.0 -> 0.12.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/near/near-sandbox/compare/v0.11.0...v0.12.0) - 2024-11-15

### Other

- Updated near-sandbox version to 2.3.1 version ([#103](https://github.com/near/near-sandbox/pull/103))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).