### PR TITLE
chore: release v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox-utils"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "binary-install",

--- a/crate/CHANGELOG.md
+++ b/crate/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/near/near-sandbox/compare/v0.13.0...v0.14.0) - 2025-03-14
+
+### Other
+
+- [**breaking**] updates near-sandbox to nearcore 2.5.0 ([#109](https://github.com/near/near-sandbox/pull/109))
+
 ## [0.13.0](https://github.com/near/near-sandbox/compare/v0.12.0...v0.13.0) - 2024-12-17
 
 ### Other

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-sandbox-utils"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/sandbox"


### PR DESCRIPTION



## 🤖 New release

* `near-sandbox-utils`: 0.13.0 -> 0.14.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0](https://github.com/near/near-sandbox/compare/v0.13.0...v0.14.0) - 2025-03-14

### Other

- [**breaking**] updates near-sandbox to nearcore 2.5.0 ([#109](https://github.com/near/near-sandbox/pull/109))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).