### PR TITLE
bugfix: should fix the job by using absolute path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npm run release
+          cwd: "${{ github.workspace }}/npm"
           commit: "chore(release): publish packages"
           title: "Publish packages"
           createGithubReleases: true


### PR DESCRIPTION
This should resolve the problem with the npm cd job.
For more details, see https://github.com/changesets/action/issues/475